### PR TITLE
Ollama startup

### DIFF
--- a/modelmux/src/components/ChatInterface/chat-message-actions.tsx
+++ b/modelmux/src/components/ChatInterface/chat-message-actions.tsx
@@ -12,26 +12,32 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useEffect, useState } from "react";
-import { getCurrentModel } from "@/lib/ollama";
+import { getCurrentModel, modelList } from "@/lib/ollama";
+import { ModelResponse } from "ollama";
 
 export function ChatMessageActions() {
   const [modelName, setModelName] = useState<string | undefined>("");
+  const [models, setModels] = useState<ModelResponse[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
-    async function fetchModel() {
+    async function fetchData() {
       try {
         setLoading(true);
-        const model = await getCurrentModel();
+        const [model, modelData] = await Promise.all([
+          getCurrentModel(),
+          modelList(),
+        ]);
         setModelName(model);
+        setModels(modelData);
       } catch (err) {
         setError(err as Error);
       } finally {
         setLoading(false);
       }
     }
-    fetchModel();
+    fetchData();
   }, []);
 
   return (
@@ -66,7 +72,10 @@ export function ChatMessageActions() {
             <RotateCcw className="h-3 w-3" />
             Retry
           </DropdownMenuItem>
-          //TODO MAP TO ALL INSTALLED LLM's
+          <DropdownMenuSeparator />
+          {models.map((model) => (
+            <DropdownMenuItem key={model.name}>{model.name}</DropdownMenuItem>
+          ))}
           <DropdownMenuSeparator />
           <DropdownMenuItem>Copy message</DropdownMenuItem>
           <DropdownMenuItem>Report issue</DropdownMenuItem>

--- a/modelmux/src/lib/ollama.ts
+++ b/modelmux/src/lib/ollama.ts
@@ -1,5 +1,4 @@
 import ollama from "ollama";
-import { list } from "postcss";
 
 interface MemoryMessage {
   role: "user" | "system" | "assistant";

--- a/modelmux/src/lib/ollama.ts
+++ b/modelmux/src/lib/ollama.ts
@@ -1,4 +1,5 @@
 import ollama from "ollama";
+import { list } from "postcss";
 
 interface MemoryMessage {
   role: "user" | "system" | "assistant";
@@ -34,7 +35,7 @@ export async function Response(
 
 export async function modelList() {
   const list = await ollama.list();
-  return list;
+  return list.models;
 }
 
 export async function getCurrentModel() {


### PR DESCRIPTION
## Acceptance Criteria

- [x] When the Electron app starts, it should automatically run the command to start Ollama (e.g., `ollama serve`)
- [x] The command should only run **once** on startup, not multiple times or after every reload
- [x] Any errors from the command should be logged to the console for debugging
- [x] The command should not block the main thread
- [x] Make sure the ollama process ends on app exit
